### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -16,9 +16,10 @@ investmate/
 │   └── main_test.go         # Tests for main-package functions
 ├── internal/
 │   ├── domain/
-│   │   └── entities/
-│   │       ├── etf.go       # ETF struct and all calculation/formatting methods
-│   │       └── etf_test.go  # Unit tests for entity logic
+│   │   ├── entities/
+│   │   │   ├── etf.go       # ETF struct and all calculation/formatting methods
+│   │   │   └── etf_test.go  # Unit tests for entity logic
+│   │   └── repositories/    # Port interfaces (DividendsRepository, PricesRepository)
 │   └── infrastructure/
 │       └── repositories/
 │           ├── nasdaq/      # NASDAQ REST API adapters (dividends + closing prices)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to add missing `internal/domain/repositories/` directory to the repository structure tree
+
 ## [0.1.10] - 2026-05-22
 
 ### Changed


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.