### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 ### Changed
 
 - changed the Go module dependencies to their latest versions
+- refreshed `CLAUDE.md` build/run commands to invoke `go build`/`go run` against `./cmd` (the Makefile targets still reference the removed `./cmd/investmate` path)
 
 ## [0.1.12] - 2026-06-03
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,11 @@ InvestMate is a Go CLI application that fetches ETF financial data (dividend cas
 ## Build, Test, and Lint
 
 ```bash
-# Build
-make build                # Binary to bin/investmate
-make run                  # Run directly (fetches live NASDAQ data)
+# Build / run — entry point is the package at ./cmd (cmd/main.go).
+# NOTE: the Makefile build/run/debug/install targets point at ./cmd/investmate,
+# which no longer exists, so invoke go directly:
+go build -o bin/investmate ./cmd   # Binary to bin/investmate
+go run ./cmd                        # Run directly (fetches live NASDAQ data)
 
 # Test
 go test ./...             # All tests (some call live NASDAQ APIs, requires network)


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.