### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -112,11 +112,12 @@ commits. SonarCloud is used for static analysis and coverage reporting.
 
 ## Configuration
 
-The two key compile-time constants in `cmd/main.go` control behaviour:
+Two compile-time constants in `cmd/main.go` control behaviour:
 
 ```go
 const (
-    YearsToFetch = 5 // How many years of historical data to fetch and display
+    YearsToFetch          = 5 // How many years of historical data to fetch and display
+    targetYieldPercentage = 9 // Minimum dividend yield coloured green; below is coloured red
 )
 ```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to document the `targetYieldPercentage` compile-time constant
+
 ## [0.1.19] - 2026-07-27
 
 ### Changed


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.